### PR TITLE
Add Mocha test suite for users endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "backbone-express-boilerplate",
   "version": "1.0.0",
   "scripts": {
-    "start": "node ./server/bin/www"
+    "start": "node ./server/bin/www",
+    "test": "mocha"
   },
   "dependencies": {
     "express": "latest",
@@ -12,6 +13,10 @@
     "morgan": "latest",
     "pug": "latest",
     "serve-favicon": "latest"
+  },
+  "devDependencies": {
+    "mocha": "^10.0.0",
+    "supertest": "^6.3.3"
   },
 
   "description": "Boilerplate project for node, express and backbone",

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -1,0 +1,18 @@
+const request = require('supertest');
+const assert = require('assert');
+const app = require('../server/app');
+
+describe('GET /users', function () {
+  it('responds with array of users and status 200', function (done) {
+    request(app)
+      .get('/users')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err);
+        assert(Array.isArray(res.body));
+        assert(res.body.every(u => typeof u === 'object'));
+        done();
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- add Mocha and Supertest as dev dependencies
- create `test/` directory with `users.test.js`
- wire up `npm test` script

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fef9c8f948320a909919ef6fa5a6c