### PR TITLE
Align default server port with README

### DIFF
--- a/server/bin/www
+++ b/server/bin/www
@@ -22,7 +22,7 @@ var options = {
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '8000');
+var port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
 /**


### PR DESCRIPTION
## Summary
- default the server to port 3000 instead of 8000

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fef9b1d68832088929c7427cafe5a