### PR TITLE
Fix https port configuration

### DIFF
--- a/server/bin/www
+++ b/server/bin/www
@@ -43,8 +43,9 @@ server.on('listening', onListening);
 /**
  * Get https port from environment and store in Express.
  */
-var httpsPort = normalizePort(process.env.PORT || '3000');
-app.set('httpsPort', port);
+// Use a separate environment variable for the HTTPS port if provided
+var httpsPort = normalizePort(process.env.HTTPS_PORT || '3000');
+app.set('httpsPort', httpsPort);
 
 /**
  * create https server


### PR DESCRIPTION
## Summary
- fix misassigned https port when starting server
- allow HTTPS port to be configured using `HTTPS_PORT` env var

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683feec40f5c832089d214fc643973e5